### PR TITLE
Use https:// rather than http:// when mirroring

### DIFF
--- a/WPepub/convert.py
+++ b/WPepub/convert.py
@@ -19,7 +19,7 @@ def WP_convert():
         if li.li is None:
             print li.a.contents[0], li.a.get('href')
             url = li.a.get('href')
-            mirror_path = os.path.join(url.replace('http://parahumans.wordpress.com', '../mirror'), 'index.html')
+            mirror_path = os.path.join(url.replace('https://parahumans.wordpress.com', '../mirror'), 'index.html')
             mirror_path = mirror_path.encode('ascii', 'ignore')
             if 'arc-29' in mirror_path:
                 break

--- a/WPepub/scrape.py
+++ b/WPepub/scrape.py
@@ -6,7 +6,7 @@ from utils import html2rst, Chapter
 
 def WP_scrape():
     # Pull down a single episode in order to extract the TOC
-    page_content = subprocess.check_output(['curl', 'http://parahumans.wordpress.com/category/stories-arcs-1-10/arc-4-shell/4-x-interlude/'])
+    page_content = subprocess.check_output(['curl', 'https://parahumans.wordpress.com/category/stories-arcs-1-10/arc-4-shell/4-x-interlude/'])
 
     soup = BeautifulSoup(page_content)
 
@@ -19,7 +19,7 @@ def WP_scrape():
         if li.li is None:
             print li.a.contents[0], li.a.get('href')
             url = li.a.get('href')
-            mirror_path = os.path.join(url.replace('http://parahumans.wordpress.com', '../mirror'),'index.html')
+            mirror_path = os.path.join(url.replace('https://parahumans.wordpress.com', '../mirror'),'index.html')
             mirror_path = mirror_path.encode('ascii', 'ignore')
             os.system('mkdir -p ' + os.path.split(mirror_path)[0])
             with open(mirror_path, 'w') as f:


### PR DESCRIPTION
Accessing the site over http results in a 301 error.
